### PR TITLE
fix: Correcting link to cluster-setup

### DIFF
--- a/_includes/getstarted.html
+++ b/_includes/getstarted.html
@@ -18,7 +18,7 @@
                 <div class="col-lg-7">
                     Run the above command in your terminal to bring up a Screwdriver cluster locally.
                     <br /><br />
-                    For setting up a production environment, take a look at our <a href="http://docs.screwdriver.cd/cluster-management/">documentation for cluster management.</a>
+                    For setting up a production environment, take a look at our <a href="http://docs.screwdriver.cd/getting-started/cluster-setup/">documentation for cluster management.</a>
                 </div>
                 <div class="col-lg-3">
                     Minimum Requirements:


### PR DESCRIPTION
This is only temporary as I'm sure we'll be refactoring the guide starting Monday.