### PR TITLE
Fix broken canonical URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 
 # Site settings
-url: https://screwdriver.cd
+url: http://screwdriver.cd
 title: screwdriver.cd
 # email: your-email@domain.com
 # description:


### PR DESCRIPTION
<img width="634" alt="screen shot 2017-01-12 at 4 03 12 pm" src="https://cloud.githubusercontent.com/assets/401283/21908384/8c379fe0-d8e1-11e6-80aa-0202afc3a505.png">

Hey Screwdriver peeps,

Today I noticed that https://screwdriver.cd/ is being indexed by Google since it's being set as the canonical URL in [`_includes/head.html`](https://github.com/screwdriver-cd/homepage/blob/6a8f1ebe1e935cac6c9c84caa97df6b895bcb00a/_includes/head.html#L7)

The problem is that the HTTPS version of the page has an SSL warning since it's currently hosted on GitHub Pages which doesn't support SSL on custom domains :(

An alternate fix for this issue might be to move the site away from GitHub pages, or to just remove the canonical meta tag from the template altogether.
