### PR TITLE
fix: Change Contact Us link to point to Support page in guide

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -24,7 +24,7 @@
                 <div class="col-md-3">
                     <h4>Community</h4>
                     <ul class="quicklinks">
-                        <li><a href="https://slack.screwdriver.cd">Contact Us</a>
+                        <li><a href="http://docs.screwdriver.cd/about/support">Contact Us</a>
                         </li>
                         <li><a href="http://blog.screwdriver.cd">Blog</a>
                         </li>


### PR DESCRIPTION
Switching link to point to Support page in the guide as it provides more details/context for users vs just a Slack inviter.