### PR TITLE
fix: adding margin to the new logo

### DIFF
--- a/_includes/css/agency.css
+++ b/_includes/css/agency.css
@@ -188,6 +188,8 @@ fieldset[disabled] .btn-xl.active {
     font-family: Montserrat, "Helvetica Neue",Helvetica,Arial,sans-serif;
     text-transform: uppercase;
     color: #{{ site.data.template.color.primary }};
+    margin-top: 12px;
+    margin-left: 10px;
 }
 
 .navbar-default .navbar-brand:hover,


### PR DESCRIPTION
So after the new logo was added, there was no margins or spacing between the logo and the page borders:

Desktop:
![screen shot 2017-06-02 at 1 51 57 pm](https://cloud.githubusercontent.com/assets/517051/26744418/afdf1dba-479a-11e7-9b31-15b50e21985e.png)

Mobiles (resolutions):
![screen shot 2017-06-02 at 1 52 26 pm](https://cloud.githubusercontent.com/assets/517051/26744428/bcc51ade-479a-11e7-8448-82eeea71bde0.png)

After the fix
------

Desktop:
![screen shot 2017-06-02 at 1 53 19 pm](https://cloud.githubusercontent.com/assets/517051/26744464/dead3898-479a-11e7-92b5-321ea0b30df1.png)

Mobile:
![screen shot 2017-06-02 at 1 53 04 pm](https://cloud.githubusercontent.com/assets/517051/26744452/d1ed9e72-479a-11e7-81e9-6ddf5a7f296f.png)

