### PR TITLE
fix(footer): Add correct link to contributing

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -15,7 +15,7 @@
                 <div class="col-md-3">
                     <h4>Contribute</h4>
                     <ul class="quicklinks">
-                        <li><a href="http://docs.screwdriver.cd/about/contributing/">Contributing</a>
+                        <li><a href="http://docs.screwdriver.cd/about/contributing">Contributing</a>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
## Context

The link to contributing in the footer has a trailing `/` which is causing a 404

## Objective

Fix link to contributing by removing the trailing `/`