### PR TITLE
fix: Add more description to the getting start section

### DIFF
--- a/_includes/getstarted.html
+++ b/_includes/getstarted.html
@@ -9,18 +9,24 @@
             <div class="row">
                 <div class="col-lg-1"></div>
                 <div class="col-lg-10">
+                    Run the command below in your terminal to bring up a Screwdriver cluster locally.
+                    <br /><br />
                     <pre>python <(curl https://raw.githubusercontent.com/screwdriver-cd/screwdriver/master/in-a-box.py)</pre>
                 </div>
                 <div class="col-lg-1"></div>
             </div>
             <div class="row">
                 <div class="col-lg-1"></div>
-                <div class="col-lg-7">
-                    Run the above command in your terminal to bring up a Screwdriver cluster locally.
+                <div class="col-lg-8">
                     <br /><br />
-                    For setting up a production environment, take a look at our <a href="http://docs.screwdriver.cd/cluster-management/">documentation for cluster management.</a>
+                    This command will run a script that will create a Docker Compose file for you locally, complete with Oauth credentials using a generated JWT and a user-provided Oauth Client ID and secret.
+                    If you choose to do so, it will then Docker pull the Screwdriver API, UI, and log store images to bring up an entire Screwdriver instance locally for you to play with.
+                    All data written to a database will be stored in a /data directory.
+                    <br /><br />
+                    For setting up a production environment, take a look at our <a href="http://docs.screwdriver.cd/cluster-management">documentation for cluster management.</a>
                 </div>
-                <div class="col-lg-3">
+                <div class="col-lg-2">
+                    <br /><br />
                     Minimum Requirements:
                     <ul>
                         <li>Python 2.7</li>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -19,16 +19,16 @@
                         <a href="#page-top"></a>
                     </li>
                     <li>
-                        <a class="page-scroll" href="http://docs.screwdriver.cd">Docs</a>
+                        <a class="page-scroll" href="http://docs.screwdriver.cd">Guide</a>
                     </li>
                     <li>
                         <a class="page-scroll" href="http://blog.screwdriver.cd">Blog</a>
                     </li>
                     <li>
-                        <a class="page-scroll" href="http://slack.screwdriver.cd">Slack</a>
+                        <a class="page-scroll" href="http://docs.screwdriver.cd/about/support">Contact Us</a>
                     </li>
                     <li>
-                        <a class="page-scroll" href="http://github.com/screwdriver-cd">GitHub</a>
+                        <a class="page-scroll" href="http://docs.screwdriver.cd/about/contributing">Contributing</a>
                     </li>
                 </ul>
             </div>

--- a/js/agency.js
+++ b/js/agency.js
@@ -6,10 +6,12 @@
 
 // jQuery for page scrolling feature - requires jQuery Easing plugin
 $(function() {
+    var navbarHeight = $('.navbar').outerHeight();
+
     $('a.page-scroll').bind('click', function(event) {
         var $anchor = $(this);
         $('html, body').stop().animate({
-            scrollTop: $($anchor.attr('href')).offset().top
+            scrollTop: $($anchor.attr('href')).offset().top - navbarHeight
         }, 1500, 'easeInOutExpo');
         event.preventDefault();
     });


### PR DESCRIPTION
- Rename links at the top: linking to the contributing docs might make more sense than Github directly; not sure if everyone knows what Slack is as well
- Add logic so that clicking TRY IT TODAY doesn't cut off the title


Clicking the button before:
<img width="1440" alt="screen shot 2017-08-04 at 6 03 44 pm" src="https://user-images.githubusercontent.com/3230529/28991635-49458d56-793f-11e7-9ae2-f724806a2f4c.png">

Clicking the button now:
<img width="1440" alt="screen shot 2017-08-10 at 12 31 47 pm" src="https://user-images.githubusercontent.com/3230529/29188440-eb5bc8f8-7dc7-11e7-8203-2cc17b66d5ab.png">

