### PR TITLE
fix(879): Updating in-a-box link.

### DIFF
--- a/_includes/getstarted.html
+++ b/_includes/getstarted.html
@@ -11,7 +11,7 @@
                 <div class="col-lg-10">
                     Run the command below in your terminal to bring up a Screwdriver cluster locally.
                     <br /><br />
-                    <pre>python <(curl https://raw.githubusercontent.com/screwdriver-cd/screwdriver/master/in-a-box.py)</pre>
+                    <pre>python <(curl -L https://git.io/screwdriver-box)</pre>
                 </div>
                 <div class="col-lg-1"></div>
             </div>


### PR DESCRIPTION
We updated all the links except the one on the homepage.

Resolves https://github.com/screwdriver-cd/screwdriver/issues/879