### PR TITLE
fix: Use git-ssh script from toolbox repo

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,19 +1,18 @@
-workflow:
-    - publish
-
 shared:
     image: ruby:2
 
 jobs:
     main:
+        requires: [~pr, ~commit]
         steps:
             - init: bundle install
             - doctor: bundle exec rake doctor
             - build: bundle exec rake build
 
     publish:
+        requires: [main]
         steps:
-            - setup-ci: git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci
+            - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
             - init: bundle install
             - publish: bundle exec ./deploy.sh
         secrets:


### PR DESCRIPTION
## Context

Build is failing at publish step when validating good hosts: https://cd.screwdriver.cd/pipelines/32/builds/16473

## Objective

- Switch to using git-ssh.sh script from the toolbox repo rather than St. John's scripts
- Also use new workflow config format

## Related links
- Old script: https://gist.github.com/stjohnjohnson/3d2388b2a7ba658cdcdaffa8cd874e50#file-git-ssh-sh
- Toolbox script: https://github.com/screwdriver-cd/toolbox/blob/master/git-ssh.sh