### PR TITLE
fix: Add link to cd.screwdriver.cd

### DIFF
--- a/_includes/css/agency.css
+++ b/_includes/css/agency.css
@@ -35,6 +35,7 @@ a:focus,
 a:active,
 a.active {
     outline: 0;
+    text-decoration: none;
 }
 
 a {

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -42,7 +42,7 @@
         <div class="layer">
             <div class="container">
                 <div class="intro-text">
-                    <div class="intro-heading">Screwdriver</div>
+                    <a class="intro-heading" href="http://cd.screwdriver.cd">Screwdriver</a>
                     <div class="intro-lead-in">Build. Test. Deploy.</div>
                     <a href="#getting-started" class="page-scroll btn btn-xl">Try it today</a>
                 </div>


### PR DESCRIPTION
## Context
Now that we've added Guest Mode, it would be nice for potential Screwdriver users to be able to see our instance of Screwdriver.

## Objective
This PR adds a link to cd.screwdriver.cd in the Screwdriver title on the homepage.

<img width="1440" alt="screen shot 2018-03-20 at 5 32 47 pm" src="https://user-images.githubusercontent.com/3230529/37689916-15797a8a-2c65-11e8-9eba-37a7c9930004.png">

## Related links
- Concourse does something similar by linking to their instance on their homepage: https://concourse-ci.org/index.html