### PR TITLE
fix: use body mask to prevent being iframed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,10 +4,6 @@ url: http://screwdriver.cd
 title: screwdriver.cd
 analytics: UA-88158708-2
 
-webrick:
-  headers:
-    X-Frame-Options: SAMEORIGIN
-
 social:
   - title: slack
     url: http://slack.screwdriver.cd

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,6 +4,21 @@
     <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
     <meta name="viewport" content="width=device-width">
     <meta name="description" content="{{ site.description }}">
+
+    <style id="antiClickjack">
+        body {
+            display: none !important;
+        }
+    </style>
+
+    <script type="text/javascript">
+        if (window.top === window.self) {
+            var antiClickjack = document.getElementById("antiClickjack");
+
+            antiClickjack.parentNode.removeChild(antiClickjack);
+        }
+    </script>
+
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
     <link rel="shortcut icon" href="../brand/LOGOS/favicons/favicon.ico" type="image/x-icon">
 
@@ -25,7 +40,7 @@
         <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
         <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
-    
+
     <!-- CDF -->
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-154682132-5"></script>


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Since modifying HTTP response in GitHub page is not possible, see https://github.com/github/pages-gem/issues/415, so `X-Frame-Options` is not viable like we tried in https://github.com/screwdriver-cd/homepage/pull/77

I also tried to insert the following to the HTML head as meta tags:

```
<meta http-equiv="Content-Security-Policy" content="frame-ancestors 'self';">
```

yet,
> [frame-ancestors](https://content-security-policy.com/frame-ancestors/) directive from a Content-Security-Policy meta tag. It must be specified as part of a Content-Security-Policy header.

![image](https://c.tenor.com/VEwrjfJ5QXAAAAAC/ball-and-chain.gif)

So far I think this approach is more suitable if we have to be chained with 

```html
<style id="antiClickjack">
    body {
        display: none !important;
    }
</style>

<script type="text/javascript">
    if (window.top === window.self) {
        var antiClickjack = document.getElementById("antiClickjack");
        antiClickjack.parentNode.removeChild(antiClickjack);
    }
</script>
```

The idea is to mask the webpage, and remove the div only when the webpage is on top of all pages, which would only happen if it's not embedded inside iframe/iframe set

Reference and credits goes to: https://ziplineb2b.com/blog/how-to-prevent-a-website-from-being-loaded-in-an-iframe/

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
