### PR TITLE
fix: update to use tinyurl instead of git.io

### DIFF
--- a/_includes/getstarted.html
+++ b/_includes/getstarted.html
@@ -11,7 +11,7 @@
                 <div class="col-lg-10">
                     Run the command below in your terminal to bring up a Screwdriver cluster locally.
                     <br /><br />
-                    <pre>python <(curl -L https://git.io/sd-in-a-box)</pre>
+                    <pre>python <(curl -L https://tinyurl.com/sd-in-a-box)</pre>
                 </div>
                 <div class="col-lg-1"></div>
             </div>


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Per github announcment: https://github.blog/changelog/2022-04-25-git-io-deprecation 
Need to switch git.io to other url shorten services, I updated to use tinyurl here

## Objective
![image](https://user-images.githubusercontent.com/15989893/165353586-69422ee5-3b12-448b-9aae-f2e8377c626f.png)

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
